### PR TITLE
Add syntax highlighting on blog front page

### DIFF
--- a/gutenberg/class-simple-code-block-gutenberg.php
+++ b/gutenberg/class-simple-code-block-gutenberg.php
@@ -111,7 +111,7 @@ class Simple_Code_Block_Gutenberg {
 			return;
 		}
 
-		if ( has_block('simple-code-block/ace') || is_archive() ) {
+		if ( has_block('simple-code-block/ace') || is_archive() || is_home() ) {
 			
 			wp_enqueue_script(
 				'simple-code-block-gutenberg-frontend-ace',


### PR DESCRIPTION
The Javascript which does the highlighting was not included on the front
page of the blog, but now is.